### PR TITLE
updated screen ruler calibration activity to automatically save data

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlycameraruler/screenruler/CalibrationActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlycameraruler/screenruler/CalibrationActivity.java
@@ -74,6 +74,7 @@ public class CalibrationActivity extends AppCompatActivity {
                 if (inputText.isEmpty()) {
                     emptyInputToast.show();
                 } else {
+                    isSubmit = true;
                     float length = Float.parseFloat(inputText);
                     boolean inchMode = ((RadioButton) findViewById(R.id.inchRadioButton)).isChecked();
                     if (inchMode) {
@@ -94,4 +95,30 @@ public class CalibrationActivity extends AppCompatActivity {
 
     }
 
+    private SharedPreferences spGen;
+
+    private boolean isSubmit;
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        SharedPreferences.Editor spGenEditor = spGen.edit();
+        if (isSubmit) {
+            spGenEditor.putString("editInput", "");
+            spGenEditor.putBoolean("editIsInch", false);
+        } else {
+            spGenEditor.putString("editInput", ((EditText) findViewById(R.id.input)).getText().toString());
+            spGenEditor.putBoolean("editIsInch", ((RadioButton) findViewById(R.id.inchRadioButton)).isChecked());
+        }
+        spGenEditor.commit();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        spGen = getSharedPreferences("CalibrationActivity", MODE_PRIVATE);
+        ((EditText) findViewById(R.id.input)).setText(spGen.getString("editInput", ""));
+        ((RadioButton) findViewById(R.id.inchRadioButton)).setChecked(spGen.getBoolean("editIsInch", false));
+        isSubmit = false;
+    }
 }


### PR DESCRIPTION
Hello developers of Tape Measure

I am using your app Tape Measure. I think the app is great but I have one minor patch that could improve the user experience.

Here is a picture to help illustrate what activity that are changed in my patch:

https://ibb.co/5vLYhz1

When the user tries to enter calibration data. If the screen focus goes to another app or activity(for example if an incoming call forces the user to go into the phone app), the user will lose any data they had put into this page if the app is force closed by Android.

This feature will automatically store the data when the user leaves the activity without submitting and restore said data when they restart the activity(this can be seen here where I closed the activity and restarted it https://ibb.co/FWzQKDC). Therefore, the user does not have to fill in the data again thus improving the user experience.

If you have any questions or if you would like me to change anything, please do not hesitate to let me know!

Thank you for your time,
Tim